### PR TITLE
 s/Node Package Manager/npm/

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is where the code for the Mozilla Developer Tools slide deck generator lives. _It's not finished yet_ and so it won't do very much for you.
 
-You don't need to clone this repo to use the generator. Use Node Package Manager. See instructions below.
+You don't need to clone this repo to use the generator. Use `npm`. See instructions below.
 
 ## Intended Audience
 


### PR DESCRIPTION
npm doesn't stand for Node Package Manager (though it's a common myth). See https://docs.npmjs.com/misc/faq#if-npm-is-an-acronym-why-is-it-never-capitalized
